### PR TITLE
Added a maven assembly jar with dependencies.

### DIFF
--- a/java-backend/nativeServer/pom.xml
+++ b/java-backend/nativeServer/pom.xml
@@ -23,6 +23,28 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.5.3</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>com.github.CambridgeAlphaTeam.Server</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
When you run `mvn package` then everything will be packaged into the jar
`*-jar-with-dependencies.jar`, so that you can just run `java -jar
target/*-jar-with-dependencies.jar` instead of using the exec plugin.